### PR TITLE
Update esp8266-weather-station-color.ino

### DIFF
--- a/esp8266-weather-station-color.ino
+++ b/esp8266-weather-station-color.ino
@@ -306,7 +306,7 @@ void updateData() {
   moonData = astronomy->calculateMoonData(time(nullptr));
   float lunarMonth = 29.53;
   moonAge = moonData.phase <= 4 ? lunarMonth * moonData.illumination / 2 : lunarMonth - moonData.illumination * lunarMonth / 2;
-  moonAgeImage = String((char) (65 + ((uint8_t) ((26 * moonAge / 30) % 26))));
+  moonAgeImage = String((char) (65 + ((uint8_t) (((26 * moonAge / 30) + 14) % 26))));
   delete astronomy;
   astronomy = nullptr;
   delay(1000);


### PR DESCRIPTION
Invert Moonphase color to show shining Moon white

On the black display ILI9341 the shining part of the moon is displayed black. I tried this fix to invert the color by shifting the moon phase for 14 days. Please check, if there is a better fix possible.

- [x ] This PR is compliant with the [other contributing guidelines](https://github.com/ThingPulse/esp8266-weather-station-color/blob/master/CONTRIBUTING.md) as well (if not, please describe why).
- [x ] I have thoroughly tested my contribution.
- [x ] Should this code require changes to documentation I will contribute those to [https://github.com/ThingPulse/docs](https://github.com/ThingPulse/docs).


