### PR TITLE
return explicit booleans

### DIFF
--- a/TouchControllerWS.cpp
+++ b/TouchControllerWS.cpp
@@ -29,7 +29,7 @@ bool TouchControllerWS::loadCalibration() {
 
   }
   f.close();
-
+  return true;
 }
 
 bool TouchControllerWS::saveCalibration() {
@@ -39,6 +39,7 @@ bool TouchControllerWS::saveCalibration() {
   File f = SPIFFS.open("/calibration.txt", "w");
   if (!f) {
     Serial.println("file creation failed");
+    return false;
   }
   // now write two lines in key/value style with  end-of-line characters
   f.println(dx);
@@ -47,6 +48,7 @@ bool TouchControllerWS::saveCalibration() {
   f.println(ay);
 
   f.close();
+  return true;
 }
 
 void TouchControllerWS::startCalibration(CalibrationCallback *calibrationCallback) {


### PR DESCRIPTION
I was being prompted to calibrate on every power-up or reset. Returning explicit boolean values
from these methods fixed it for me.
