### PR TITLE
MAX_FORECASTS duplicated

### DIFF
--- a/settings.h
+++ b/settings.h
@@ -50,7 +50,6 @@ Slovenian -> sl, Spanish -> es, Turkish -> tr, Ukrainian -> ua, Vietnamese -> vi
 Chinese Simplified -> zh_cn, Chinese Traditional -> zh_tw.
 */
 String OPEN_WEATHER_MAP_LANGUAGE = "en";
-const uint8_t MAX_FORECASTS = 10;
 
 // Adjust according to your language
 const String WDAY_NAMES[] = {"SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"};


### PR DESCRIPTION
MAX_FORECASTS exists in both settings.h and esp8266-weather-station-color.ino.
In settings.h, it is unused and its value 10 is wrong (should be 12 since 12 forecasts are to be displayed). So it should be removed.